### PR TITLE
Dedup osm/OA addresses

### DIFF
--- a/middleware/dedupe.js
+++ b/middleware/dedupe.js
@@ -64,13 +64,13 @@ function dedupeResults(req, res, next) {
 
 function isPreferred(existing, candidateReplacement) {
   // NOTE: we are assuming here that the layer for both records is the same
-
-  var isOA = _.flow(_.property('source'), _.eq.bind(null, 'openaddresses'));
-  var hasZip = _.bind(_.has, null, _.bind.placeholder, 'address_parts.zip');
+  const hasZip = _.bind(_.has, null, _.bind.placeholder, 'address_parts.zip');
 
   // https://github.com/pelias/api/issues/872
-  if (isOA(existing) && isOA(candidateReplacement)) {
-    return hasZip(candidateReplacement) && !hasZip(existing);
+  const candidateHasZip = hasZip(candidateReplacement);
+  const existingHasZip = hasZip(existing);
+  if (candidateHasZip !== existingHasZip) {
+    return candidateHasZip;
   }
 
   //bind the trumps function to the data items to keep the rest of the function clean

--- a/test/unit/middleware/dedupe.js
+++ b/test/unit/middleware/dedupe.js
@@ -222,6 +222,42 @@ module.exports.tests.trump = function(test, common) {
       t.end();
     });
   });
+
+test('osm with zip trumps openaddresses without zip', function (t) {
+  var req = {
+    clean: {
+      text: '100 Main St',
+      size: 100
+    }
+  };
+  var res = {
+    data:  [
+      {
+        'name': { 'default': '100 Main St' },
+        'source': 'openaddresses',
+        'source_id': '123456',
+        'layer': 'address',
+        'address_parts': {}
+      },
+      {
+        'name': { 'default': '100 Main St' },
+        'source': 'openstreetmap',
+        'source_id': '654321',
+        'layer': 'address',
+        'address_parts': {
+          'zip': '54321'
+        }
+      }
+    ]
+  };
+
+  var expectedCount = 1;
+  dedupe(req, res, function () {
+    t.equal(res.data.length, expectedCount, 'results have fewer items than before');
+    t.deepEqual(res.data[0].source_id, '654321', 'openstreetmap result with zip won');
+    t.end();
+  });
+});
 };
 
 module.exports.all = function (tape, common) {


### PR DESCRIPTION
By @antoine-de : 

linked to https://github.com/pelias/pelias/issues/541
and maybe to https://github.com/pelias/pelias/issues/541 but I cannot
reproduce it.

and to the fact that there are lots of duplicates in france like:
[20 rue hector malot
paris](https://mapzen.com/search/explorer/?query=search&text=20%20rue%20hector%20malot%20paris)
that returns 1 result from open address and 1 result from OSM

now we first check which source has a zipcode and if both have, we
prefer OA over OSM